### PR TITLE
Fix a compatibility Issue

### DIFF
--- a/sushiro
+++ b/sushiro
@@ -38,7 +38,8 @@ while [[ "${#}" -gt 0 ]]; do
       | grep -e '="ttl"' -e price \
       | sed 's/<[^>]*>//g;s/ + /+/g;s/場合 /場合/g;/^$/d' \
       | tr '\n' ' ' \
-      | sed 's/税　/税 /g;s/ /,/g;s/l,/l\n/g' \
+      | sed 's/税　/税 /g;s/ /,/g' \
+      | awk '{gsub(/kcal,/,"kcal\n");print}' \
       | sort \
       | uniq \
       | sed 's/,倍/倍/' \
@@ -54,7 +55,8 @@ while [[ "${#}" -gt 0 ]]; do
       | grep -e '="ttl"' -e price \
       | sed 's/<[^>]*>//g;s/ + /+/g;s/場合 /場合/g;/^$/d' \
       | tr '\n' ' ' \
-      | sed 's/税　/税 /g;s/ /,/g;s/l,/l\n/g' \
+      | sed 's/税　/税 /g;s/ /,/g' \
+      | awk '{gsub(/kcal,/,"kcal\n");print}' \
       | sort \
       | uniq \
       | sed 's/,倍/倍/' \
@@ -69,7 +71,8 @@ while [[ "${#}" -gt 0 ]]; do
       | grep -e '="ttl"' -e price \
       | sed 's/<[^>]*>//g;s/ + /+/g;s/場合 /場合/g;/^$/d' \
       | tr '\n' ' ' \
-      | sed 's/税　/税 /g;s/ /,/g;s/l,/l\n/g' \
+      | sed 's/税　/税 /g;s/ /,/g' \
+      | awk '{gsub(/kcal,/,"kcal\n");print}' \
       | sort \
       | uniq \
       | sed 's/,倍/倍/' \
@@ -81,11 +84,12 @@ while [[ "${#}" -gt 0 ]]; do
       | grep -e '="ttl"' -e price \
       | sed 's/<[^>]*>//g;s/ + /+/g;s/場合 /場合/g;/^$/d' \
       | tr '\n' ' ' \
-      | sed 's/税　/税 /g;s/ /,/g;s/l,/l\n/g' \
+      | sed 's/税　/税 /g;s/ /,/g' \
+      | awk '{gsub(/kcal,/,"kcal\n");print}' \
       | sort \
       | uniq \
       | sed 's/,倍/倍/' \
-      | awk -F ',' 'NR>1{print $1}' && \
+      | awk -F, 'NR>1{print $1}' && \
       exit 0
   fi
 done


### PR DESCRIPTION
Since sed(1) in Mac can't handle \n, the replace rule is replaced
by an additional awk.

| sed 's/税　/税 /g;s/ /,/g;s/l,/l\n/g' \

| sed 's/税　/税 /g;s/ /,/g' \
| awk '{gsub(/kcal,/,"kcal\n");print}' \