### PR TITLE
be compatible with ShellgeiBot

### DIFF
--- a/sushiro
+++ b/sushiro
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
 #
 # sushiro 0.0.1
 # (C) 2018 redpeacock78
@@ -21,12 +21,22 @@
 
 ###USAGE###
 [[ "${1}" = "-h" ]] && \
-  printf "sushiro version 0.0.1\n\nUSAGE: sushiro [OPTIONS] [ANYTHING]\nOptions:\n -l NUMBER\n    Randomly display the number of specified menus\n -p MENU_NAME\n    Display price of menu corresponding to name\n -k MENU_NAME\n    Display the calorie of the name corresponding menu\n -a\n    Display names of all menus\n" && \
+  printf "sushiro version 0.0.1\n\nUSAGE: sushiro [OPTIONS] [ANYTHING]\nOptions:\n -l NUMBER\n    Randomly display the number of specified menus\n -p MENU_NAME\n    Display price of menu corresponding to name\n -k MENU_NAME\n    Display the calorie of the name corresponding menu\n -a\n    Display names of all menus\n -f\n    Fetch menus from www.akindo-sushiro.co.jp\n" && \
 exit 0
 
 
 ###TEXT###
 LINES="1"
+
+###FETCH###
+CACHE="/usr/local/share/sushiro_cache"
+
+[[ "${1}" = "-f" ]] && \
+  curl -s 'https://www.akindo-sushiro.co.jp/menu/' -o "$CACHE" &&\
+exit 0
+
+[[ ! -f "$CACHE" ]] && \
+  curl -s 'https://www.akindo-sushiro.co.jp/menu/' -o "$CACHE"
 
 while [[ "${#}" -gt 0 ]]; do
   ##RONDOM MENUS##
@@ -34,7 +44,7 @@ while [[ "${#}" -gt 0 ]]; do
     shift && \
     LINES="$(tr -dc '0-9' <<< $1)"
     shift
-    curl -s 'https://www.akindo-sushiro.co.jp/menu/' \
+    cat $CACHE \
       | grep -e '="ttl"' -e price \
       | sed 's/<[^>]*>//g;s/ + /+/g;s/場合 /場合/g;/^$/d' \
       | tr '\n' ' ' \
@@ -50,7 +60,7 @@ while [[ "${#}" -gt 0 ]]; do
     shift && \
     PRICES="$(sed 's/[[:alnum:]]//g' <<< $1)"
     shift
-    curl -s 'https://www.akindo-sushiro.co.jp/menu/' \
+    cat $CACHE \
       | grep -e '="ttl"' -e price \
       | sed 's/<[^>]*>//g;s/ + /+/g;s/場合 /場合/g;/^$/d' \
       | tr '\n' ' ' \
@@ -65,7 +75,7 @@ while [[ "${#}" -gt 0 ]]; do
     shift && \
     CALORIES="$(sed 's/[[:alnum:]]//g' <<< $1)"
     shift
-    curl -s 'https://www.akindo-sushiro.co.jp/menu/' \
+    cat $CACHE \
       | grep -e '="ttl"' -e price \
       | sed 's/<[^>]*>//g;s/ + /+/g;s/場合 /場合/g;/^$/d' \
       | tr '\n' ' ' \
@@ -77,7 +87,7 @@ while [[ "${#}" -gt 0 ]]; do
       | awk -F ',' '{print $1,$3}'
   ##SHOW_ALL_MENUS##
   elif [[ "${1}" = "-a" ]]; then
-    curl -s 'https://www.akindo-sushiro.co.jp/menu/' \
+    cat $CACHE \
       | grep -e '="ttl"' -e price \
       | sed 's/<[^>]*>//g;s/ + /+/g;s/場合 /場合/g;/^$/d' \
       | tr '\n' ' ' \


### PR DESCRIPTION
[シェル芸bot](https://twitter.com/minyoruminyon) 環境でも動作するように変更を加えました。変更点は以下のとおりです

- shebangの"-e"がついていると動かなかったので取りました（なにか意味があるようだったら別の対応も考えますので教えてください）
- -f(fetch)コマンドを導入してメニューリストをキャッシュで持つようにしました（キャッシュするファイルは `/usr/local/share/sushiro_cache` にしていますが、”お作法”はわからないので違う良い場所があれば教えてください）
